### PR TITLE
Update sensorless_homing_override.cfg

### DIFF
--- a/Klipper-Update/Smart 3/macros/sensorless_homing_override.cfg
+++ b/Klipper-Update/Smart 3/macros/sensorless_homing_override.cfg
@@ -30,8 +30,8 @@ variable_second_homed_axis: 'X'             # If the Z axis is homed first, this
 ## The following variables are used for moving the printhead to a certain part of the bed before homing the Z axis, unless Z is homed first.
 
 variable_safe_z_enable: True               # Enables/disables moving the printhead to a safe XY position before homing the Z axis.
-variable_safe_x: 140                       # Safe X position to home the Z axis, leave at -128 to home to the center of the X axis.
-variable_safe_y: 140                       # Safe Y position to home the Z axis, leave at -128 to home to the center of the Y axis.
+variable_safe_x: 92                        # Safe X position to home the Z axis, leave at -128 to home to the center of the X axis.
+variable_safe_y: 92                        # Safe Y position to home the Z axis, leave at -128 to home to the center of the Y axis.
 
 # Do not modify below
 gcode:


### PR DESCRIPTION
fixed save position XY

## Summary by Sourcery

Enhancements:
- Change the safe XY coordinates for Z homing to avoid hitting the bed.